### PR TITLE
Update test-data-stack to support Fargate services

### DIFF
--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -133,6 +133,8 @@ module "ecs-services" {
   test-data-lb-arn          = module.ecs-stack.test-data-lb-listener-arn
   test-data-lb-listener-arn = module.ecs-stack.test-data-lb-listener-arn
   vpc_id                    = local.vpc_id
+  subnet_ids                = local.application_ids
+  web_access_cidrs          = concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs))
   aws_region                = var.aws_region
   ssl_certificate_id        = var.ssl_certificate_id
   external_top_level_domain = var.external_top_level_domain

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1-task-definition.tmpl
@@ -7,8 +7,6 @@
         ],
         "name": "ecs-stack-test-app1",
         "image": "${docker_registry}/ecs-stack-test-app1:${release_version}",
-        "cpu": 1,
-        "memory": 512,
         "mountPoints": [],
         "portMappings": [{
             "containerPort": ${application_port},

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1-task-definition.tmpl
@@ -12,7 +12,7 @@
         "mountPoints": [],
         "portMappings": [{
             "containerPort": ${application_port},
-            "hostPort": 0,
+            "hostPort": ${application_port},
             "protocol": "tcp"
         }],
         "logConfiguration": {

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
@@ -32,15 +32,15 @@ resource "aws_ecs_service" "ecs-stack-test-app1-ecs-service" {
   task_definition = aws_ecs_task_definition.ecs-stack-test-app1-task-definition.arn
   desired_count   = 1
   depends_on      = [var.test-data-lb-arn]
-  launch_type = "FARGATE"
+  launch_type     = "FARGATE"
   load_balancer {
     target_group_arn = aws_lb_target_group.ecs-stack-test-app1-target_group.arn
     container_port   = var.test1_application_port
     container_name   = "${local.test1_service_name}"
   }
   network_configuration {
-    security_groups = [aws_security_group.ecs-stack-test-app1-sg.id]
-    subnets = split(",", var.subnet_ids)
+    security_groups  = [aws_security_group.ecs-stack-test-app1-sg.id]
+    subnets          = split(",", var.subnet_ids)
     assign_public_ip = false
   }
 }
@@ -62,22 +62,22 @@ locals {
 }
 
 resource "aws_ecs_task_definition" "ecs-stack-test-app1-task-definition" {
-  family             = "${var.environment}-${local.test1_service_name}"
-  execution_role_arn = var.task_execution_role_arn
+  family                   = "${var.environment}-${local.test1_service_name}"
+  execution_role_arn       = var.task_execution_role_arn
   requires_compatibilities = ["FARGATE"]
-  network_mode = "awsvpc"
-  cpu = 512
-  memory = 1024
-  container_definitions = templatefile(
+  network_mode             = "awsvpc"
+  cpu                      = 512
+  memory                   = 1024
+  container_definitions    = templatefile(
     "${path.module}/${local.test1_service_name}-task-definition.tmpl", local.ecs-stack-test-app1-definition
   )
 }
 
 resource "aws_lb_target_group" "ecs-stack-test-app1-target_group" {
-  name     = "${var.environment}-${local.test1_service_name}-tg"
-  port     = var.test1_application_port
-  protocol = "HTTP"
-  vpc_id   = var.vpc_id
+  name        = "${var.environment}-${local.test1_service_name}-tg"
+  port        = var.test1_application_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
   target_type = "ip"
 
   health_check {

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
@@ -5,6 +5,7 @@ resource "aws_ecs_service" "ecs-stack-test-app1-ecs-service" {
   task_definition = aws_ecs_task_definition.ecs-stack-test-app1-task-definition.arn
   desired_count   = 1
   depends_on      = [var.test-data-lb-arn]
+  launch_type = "FARGATE"
   load_balancer {
     target_group_arn = aws_lb_target_group.ecs-stack-test-app1-target_group.arn
     container_port   = var.test1_application_port

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
@@ -2,6 +2,29 @@ locals {
   test1_service_name = "ecs-stack-test-app1"
 }
 
+resource "aws_security_group" "ecs-stack-test-app1-sg" {
+  description = "Security group for ${local.test1_service_name}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = var.test1_application_port
+    to_port     = var.test1_application_port
+    protocol    = "tcp"
+    cidr_blocks = var.web_access_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Environment = var.environment
+    Name        = "${local.test1_service_name}-internal-service-sg"
+  }
+}
 
 resource "aws_ecs_service" "ecs-stack-test-app1-ecs-service" {
   name            = "${var.environment}-${local.test1_service_name}"

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
@@ -38,6 +38,11 @@ resource "aws_ecs_service" "ecs-stack-test-app1-ecs-service" {
     container_port   = var.test1_application_port
     container_name   = "${local.test1_service_name}"
   }
+  network_configuration {
+    security_groups = [aws_security_group.ecs-stack-test-app1-sg.id]
+    subnets = split(",", var.subnet_ids)
+    assign_public_ip = false
+  }
 }
 
 locals {

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
@@ -38,6 +38,8 @@ resource "aws_ecs_task_definition" "ecs-stack-test-app1-task-definition" {
   execution_role_arn = var.task_execution_role_arn
   requires_compatibilities = ["FARGATE"]
   network_mode = "awsvpc"
+  cpu = 512
+  memory = 1024
   container_definitions = templatefile(
     "${path.module}/${local.test1_service_name}-task-definition.tmpl", local.ecs-stack-test-app1-definition
   )

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
@@ -36,6 +36,7 @@ locals {
 resource "aws_ecs_task_definition" "ecs-stack-test-app1-task-definition" {
   family             = "${var.environment}-${local.test1_service_name}"
   execution_role_arn = var.task_execution_role_arn
+  requires_compatibilities = ["FARGATE"]
   network_mode = "awsvpc"
   container_definitions = templatefile(
     "${path.module}/${local.test1_service_name}-task-definition.tmpl", local.ecs-stack-test-app1-definition

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
@@ -36,6 +36,7 @@ locals {
 resource "aws_ecs_task_definition" "ecs-stack-test-app1-task-definition" {
   family             = "${var.environment}-${local.test1_service_name}"
   execution_role_arn = var.task_execution_role_arn
+  network_mode = "awsvpc"
   container_definitions = templatefile(
     "${path.module}/${local.test1_service_name}-task-definition.tmpl", local.ecs-stack-test-app1-definition
   )

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
@@ -1,6 +1,10 @@
+locals {
+  test1_service_name = "ecs-stack-test-app1"
+}
+
 
 resource "aws_ecs_service" "ecs-stack-test-app1-ecs-service" {
-  name            = "${var.environment}-ecs-stack-test-app1"
+  name            = "${var.environment}-${local.test1_service_name}"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.ecs-stack-test-app1-task-definition.arn
   desired_count   = 1
@@ -9,7 +13,7 @@ resource "aws_ecs_service" "ecs-stack-test-app1-ecs-service" {
   load_balancer {
     target_group_arn = aws_lb_target_group.ecs-stack-test-app1-target_group.arn
     container_port   = var.test1_application_port
-    container_name   = "ecs-stack-test-app1"
+    container_name   = "${local.test1_service_name}"
   }
 }
 
@@ -30,15 +34,15 @@ locals {
 }
 
 resource "aws_ecs_task_definition" "ecs-stack-test-app1-task-definition" {
-  family             = "${var.environment}-ecs-stack-test-app1"
+  family             = "${var.environment}-${local.test1_service_name}"
   execution_role_arn = var.task_execution_role_arn
   container_definitions = templatefile(
-    "${path.module}/ecs-stack-test-app1-task-definition.tmpl", local.ecs-stack-test-app1-definition
+    "${path.module}/${local.test1_service_name}-task-definition.tmpl", local.ecs-stack-test-app1-definition
   )
 }
 
 resource "aws_lb_target_group" "ecs-stack-test-app1-target_group" {
-  name     = "${var.environment}-ecs-stack-test-app1-tg"
+  name     = "${var.environment}-${local.test1_service_name}-tg"
   port     = var.test1_application_port
   protocol = "HTTP"
   vpc_id   = var.vpc_id

--- a/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
+++ b/groups/stack/module-ecs-services/ecs-stack-test-app1.tf
@@ -47,6 +47,7 @@ resource "aws_lb_target_group" "ecs-stack-test-app1-target_group" {
   port     = var.test1_application_port
   protocol = "HTTP"
   vpc_id   = var.vpc_id
+  target_type = "ip"
 
   health_check {
     healthy_threshold   = "5"

--- a/groups/stack/module-ecs-services/variables.tf
+++ b/groups/stack/module-ecs-services/variables.tf
@@ -21,6 +21,14 @@ variable "test-data-lb-listener-arn" {
   type        = string
   description = "The ARN of the lb listener created in the ecs-stack module."
 }
+variable "subnet_ids" {
+  type        = string
+  description = "Subnet IDs of application subnets from aws-mm-networks remote state."
+}
+variable "web_access_cidrs" {
+  type        = list(string)
+  description = "Subnet CIDRs for web ingress rules in the security group."
+}
 
 # DNS
 variable "external_top_level_domain" {


### PR DESCRIPTION
**Branch from "feature/stagsbox-refactor"**

Makes the following changes:
- Adds configuration to support Fargate
- Sets the launch_type to "FARGATE"
- Reconfigures `test-app1` to Fargate launch.

Resolves: DVOP-1369