### PR TITLE
Update stagsbox SSL Certificate

### DIFF
--- a/groups/stack/profiles/staging-eu-west-2/stagsbox/vars
+++ b/groups/stack/profiles/staging-eu-west-2/stagsbox/vars
@@ -6,7 +6,7 @@ state_prefix = "env:/staging"
 aws_profile = "staging-eu-west-2"
 
 # Certificate for https access through ALB
-ssl_certificate_id = "arn:aws:iam::250991044064:server-certificate/Staging_2022"
+ssl_certificate_id = "arn:aws:acm:eu-west-2:250991044064:certificate/56b76dab-5728-4f83-a16d-e3dd59cd82c8"
 external_top_level_domain = "-stagsbox.companieshouse.gov.uk"
 internal_top_level_domain = "-stagsbox.staging.aws.internal"
 


### PR DESCRIPTION
Updated `ssl_certificate_id` for Stagsbox to use updated certificate