### PR TITLE
feature/ecct-869-updated the chs_kafka_api_url

### DIFF
--- a/groups/stack/profiles/staging-eu-west-2/stagsbox/vars
+++ b/groups/stack/profiles/staging-eu-west-2/stagsbox/vars
@@ -19,5 +19,5 @@ log_level = "TRACE"
 eric_cache_url = "stagsbox-chs-elasticache.3psdof.ng.0001.euw2.cache.amazonaws.com:6379"
 
 # chips filing mock configs
-chs_kafka_api_url = "http://internal-stagsbox-chs-kafka-api-1211161977.eu-west-2.elb.amazonaws.com"
+chs_kafka_api_url = "http://internal-stagsbox-chs-kafka-api-1558208271.eu-west-2.elb.amazonaws.com"
 kafka_broker_address = "kafka-broker1-stagsbox.staging.aws.internal:9092"


### PR DESCRIPTION
__Jira Number:__ [ECCT-869](https://companieshouse.atlassian.net/browse/ECCT-869)

__Short Description:__
Updated the chs_kafka_api_url to the correct ALB address for stagsbox.

[ECCT-869]: https://companieshouse.atlassian.net/browse/ECCT-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ