### PR TITLE
feature/ecct-869-updated the chs_kafka_api_url for livesbox

### DIFF
--- a/groups/stack/profiles/live-eu-west-2/livesbox/vars
+++ b/groups/stack/profiles/live-eu-west-2/livesbox/vars
@@ -24,5 +24,5 @@ log_level = "TRACE"
 eric_cache_url = "livesbox-chs-elasticache.yaky4x.ng.0001.euw2.cache.amazonaws.com:6379"
 
 # chips filing mock configs
-chs_kafka_api_url = "http://internal-livesbox-chs-kafka-api-692171571.eu-west-2.elb.amazonaws.com"
+chs_kafka_api_url = "http://internal-livesbox-chs-kafka-api-127987534.eu-west-2.elb.amazonaws.com"
 kafka_broker_address = "kafka-broker1-livesbox.live.aws.internal:9092"


### PR DESCRIPTION
__Jira Number:__ [ECCT-869](https://companieshouse.atlassian.net/browse/ECCT-869)

__Short Description:__
Updated the chs_kafka_api_url to the correct ALB address for livesbox.

[ECCT-869]: https://companieshouse.atlassian.net/browse/ECCT-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ