### PR TITLE
Permit shared services concourse

### DIFF
--- a/groups/stack/data.tf
+++ b/groups/stack/data.tf
@@ -1,0 +1,51 @@
+# Configure the remote state data source to acquire configuration
+# created through the code in ch-service-terraform/aws-mm-networks.
+data "terraform_remote_state" "networks" {
+  backend = "s3"
+  config = {
+    bucket = var.remote_state_bucket
+    key    = "${var.state_prefix}/${var.deploy_to}/${var.deploy_to}.tfstate"
+    region = var.aws_region
+  }
+}
+
+# Configure the remote state data source to acquire configuration created
+# through the code in aws-common-infrastructure-terraform/groups/networking.
+data "terraform_remote_state" "networks_common_infra" {
+  backend = "s3"
+  config = {
+    bucket = var.aws_bucket
+    key    = "aws-common-infrastructure-terraform/common-${var.aws_region}/networking.tfstate"
+    region = var.aws_region
+  }
+}
+
+# Remote state data source for Ireland, required for Concourse management CIDRs
+data "terraform_remote_state" "networks_common_infra_ireland" {
+  backend = "s3"
+  config = {
+    bucket = "development-eu-west-1.terraform-state.ch.gov.uk"
+    key    = "aws-common-infrastructure-terraform/common-eu-west-1/networking.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+# Configure the remote state data source to acquire configuration
+# created through the code in the services-stack-configs stack in the
+# aws-common-infrastructure-terraform repo.
+data "terraform_remote_state" "services-stack-configs" {
+  backend = "s3"
+  config = {
+    bucket = var.aws_bucket # aws-common-infrastructure-terraform repo uses the same remote state bucket
+    key    = "aws-common-infrastructure-terraform/common-${var.aws_region}/services-stack-configs.tfstate"
+    region = var.aws_region
+  }
+}
+
+data "vault_generic_secret" "secrets" {
+  path = "applications/${var.aws_profile}/${var.environment}/${local.stack_fullname}"
+}
+
+data "vault_generic_secret" "shared_services_concourse_cidrs" {
+  path = "aws-accounts/shared-services/build_subnet_cidrs"
+}

--- a/groups/stack/locals.tf
+++ b/groups/stack/locals.tf
@@ -1,0 +1,23 @@
+locals {
+  vpc_id            = data.terraform_remote_state.networks.outputs.vpc_id
+  application_ids   = data.terraform_remote_state.networks.outputs.application_ids
+  application_cidrs = data.terraform_remote_state.networks.outputs.application_cidrs
+  public_ids        = data.terraform_remote_state.networks.outputs.public_ids
+  public_cidrs      = data.terraform_remote_state.networks.outputs.public_cidrs
+
+  internal_cidrs = values(data.terraform_remote_state.networks_common_infra.outputs.internal_cidrs)
+  vpn_cidrs      = values(data.terraform_remote_state.networks_common_infra.outputs.vpn_cidrs)
+
+  management_private_subnet_cidrs = values(data.terraform_remote_state.networks_common_infra_ireland.outputs.management_private_subnet_cidrs)
+
+  stack_name       = "test-data"
+  stack_fullname   = "${local.stack_name}-stack"
+  name_prefix      = "${local.stack_name}-${var.environment}"
+
+  public_lb_cidrs  = ["0.0.0.0/0"]
+  lb_subnet_ids    = "${var.test_data_lb_internal ? local.application_ids : local.public_ids}" # place ALB in correct subnets
+  lb_access_cidrs  = "${var.test_data_lb_internal ? concat(local.management_private_subnet_cidrs,split(",",local.application_cidrs)) : local.public_lb_cidrs }"
+  app_access_cidrs = "${var.test_data_lb_internal ? concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs)) : concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs),split(",",local.public_cidrs)) }"
+
+  concourse_access_cidrs = values(data.vault_generic_secret.shared_services_concourse_cidrs.data)
+}

--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -1,70 +1,13 @@
-provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.32.0"
-}
-
 terraform {
   backend "s3" {
   }
 }
 
-# Configure the remote state data source to acquire configuration
-# created through the code in ch-service-terraform/aws-mm-networks.
-data "terraform_remote_state" "networks" {
-  backend = "s3"
-  config = {
-    bucket = var.remote_state_bucket
-    key    = "${var.state_prefix}/${var.deploy_to}/${var.deploy_to}.tfstate"
-    region = var.aws_region
-  }
-}
-locals {
-  vpc_id            = data.terraform_remote_state.networks.outputs.vpc_id
-  application_ids   = data.terraform_remote_state.networks.outputs.application_ids
-  application_cidrs = data.terraform_remote_state.networks.outputs.application_cidrs
-  public_ids        = data.terraform_remote_state.networks.outputs.public_ids
-  public_cidrs      = data.terraform_remote_state.networks.outputs.public_cidrs
+provider "aws" {
+  region  = var.aws_region
+  version = "~> 2.32.0"
 }
 
-# Configure the remote state data source to acquire configuration created
-# through the code in aws-common-infrastructure-terraform/groups/networking.
-data "terraform_remote_state" "networks_common_infra" {
-  backend = "s3"
-  config = {
-    bucket = var.aws_bucket
-    key    = "aws-common-infrastructure-terraform/common-${var.aws_region}/networking.tfstate"
-    region = var.aws_region
-  }
-}
-locals {
-  internal_cidrs = values(data.terraform_remote_state.networks_common_infra.outputs.internal_cidrs)
-  vpn_cidrs      = values(data.terraform_remote_state.networks_common_infra.outputs.vpn_cidrs)
-}
-
-# Remote state data source for Ireland, required for Concourse management CIDRs
-data "terraform_remote_state" "networks_common_infra_ireland" {
-  backend = "s3"
-  config = {
-    bucket = "development-eu-west-1.terraform-state.ch.gov.uk"
-    key    = "aws-common-infrastructure-terraform/common-eu-west-1/networking.tfstate"
-    region = "eu-west-1"
-  }
-}
-locals {
-  management_private_subnet_cidrs = values(data.terraform_remote_state.networks_common_infra_ireland.outputs.management_private_subnet_cidrs)
-}
-
-# Configure the remote state data source to acquire configuration
-# created through the code in the services-stack-configs stack in the
-# aws-common-infrastructure-terraform repo.
-data "terraform_remote_state" "services-stack-configs" {
-  backend = "s3"
-  config = {
-    bucket = var.aws_bucket # aws-common-infrastructure-terraform repo uses the same remote state bucket
-    key    = "aws-common-infrastructure-terraform/common-${var.aws_region}/services-stack-configs.tfstate"
-    region = var.aws_region
-  }
-}
 
 provider "vault" {
   auth_login {
@@ -73,26 +16,6 @@ provider "vault" {
       password = var.vault_password
     }
   }
-}
-
-data "vault_generic_secret" "secrets" {
-  path = "applications/${var.aws_profile}/${var.environment}/${local.stack_fullname}"
-}
-
-locals {
-  # stack name is hardcoded here in main.tf for this stack. It should not be overridden per env
-  stack_name       = "test-data"
-  stack_fullname   = "${local.stack_name}-stack"
-  name_prefix      = "${local.stack_name}-${var.environment}"
-
-  public_lb_cidrs  = ["0.0.0.0/0"]
-  lb_subnet_ids    = "${var.test_data_lb_internal ? local.application_ids : local.public_ids}" # place ALB in correct subnets
-  lb_access_cidrs  = "${var.test_data_lb_internal ?
-                      concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs)) :
-                      local.public_lb_cidrs }"
-  app_access_cidrs = "${var.test_data_lb_internal ?
-                      concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs)) :
-                      concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs),split(",",local.public_cidrs)) }"
 }
 
 module "ecs-cluster" {
@@ -135,6 +58,7 @@ module "ecs-stack" {
   subnet_ids                = local.lb_subnet_ids
   web_access_cidrs          = local.lb_access_cidrs
   test_data_lb_internal     = var.test_data_lb_internal
+  concourse_access_cidrs    = local.concourse_access_cidrs
 }
 
 module "ecs-services" {

--- a/groups/stack/module-ecs-stack/security-groups.tf
+++ b/groups/stack/module-ecs-stack/security-groups.tf
@@ -2,20 +2,6 @@ resource "aws_security_group" "internal-service-sg" {
   description = "Security group for internal service albs"
   vpc_id      = var.vpc_id
 
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = var.web_access_cidrs
-  }
-
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = var.web_access_cidrs
-  }
-
   egress {
     from_port   = 0
     to_port     = 0
@@ -27,4 +13,48 @@ resource "aws_security_group" "internal-service-sg" {
     Environment = var.environment
     Name        = "${var.name_prefix}-internal-service-sg"
   }
+}
+
+resource "aws_security_group_rule" "web_http" {
+  for_each = toset(var.web_access_cidrs)
+
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = aws_security_group.internal-service-sg.id
+}
+
+resource "aws_security_group_rule" "web_https" {
+  for_each = toset(var.web_access_cidrs)
+
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = aws_security_group.internal-service-sg.id
+}
+
+resource "aws_security_group_rule" "concourse_http" {
+  for_each = toset(var.concourse_access_cidrs)
+
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = aws_security_group.internal-service-sg.id
+}
+
+resource "aws_security_group_rule" "concourse_https" {
+  for_each = toset(var.concourse_access_cidrs)
+
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = aws_security_group.internal-service-sg.id
 }

--- a/groups/stack/module-ecs-stack/variables.tf
+++ b/groups/stack/module-ecs-stack/variables.tf
@@ -51,3 +51,8 @@ variable "ssl_certificate_id" {
   type        = string
   description = "The ARN of the certificate for https access through the ALB."
 }
+
+variable "concourse_access_cidrs" {
+  type        = list(string)
+  description = "A list of CIDR blocks used to permit access from Shared Services Concourse"
+}

--- a/groups/stack/profiles/development-eu-west-2/devops1/vars
+++ b/groups/stack/profiles/development-eu-west-2/devops1/vars
@@ -18,3 +18,11 @@ log_level = "TRACE"
 
 # eric configs
 eric_cache_url = "devops1-chs-elasticache.9vgugg.ng.0001.euw2.cache.amazonaws.com:6379"
+
+# chips filing mock configs
+kafka_broker_address = "kafka-broker1-devops1.development.aws.internal:9092"
+
+# instances of chips filing mock service to run - set to 0 to turn the service off in cidev during normal
+# testing to avoid duplicate emails and confusion for scrum teams.
+# set back to 1 temporarily to test this service in cidev but remember to set to 0 again afterwards!
+chips_filing_mock_desired_count = 0

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -182,6 +182,7 @@ variable "chips_filing_mock_desired_count" {
   default      = 1
 }
 variable "chs_kafka_api_url" {
+  default     = ""
   type        = string
 }
 variable "kafka_broker_address" {


### PR DESCRIPTION
Moved locals and data resources in to their own files
Added data lookup and locals to obtain Concourse CIDRs
Updated `ecs-stack` module to restructure security group to avoid race conditions
Added security group rules for shared-services Concourse