### PR TITLE
Changes required for upgrade to TF 0.13

### DIFF
--- a/groups/stack/locals.tf
+++ b/groups/stack/locals.tf
@@ -15,9 +15,9 @@ locals {
   name_prefix      = "${local.stack_name}-${var.environment}"
 
   public_lb_cidrs  = ["0.0.0.0/0"]
-  lb_subnet_ids    = "${var.test_data_lb_internal ? local.application_ids : local.public_ids}" # place ALB in correct subnets
-  lb_access_cidrs  = "${var.test_data_lb_internal ? concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs)) : local.public_lb_cidrs }"
-  app_access_cidrs = "${var.test_data_lb_internal ? concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs)) : concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs),split(",",local.public_cidrs)) }"
+  lb_subnet_ids    = var.test_data_lb_internal ? local.application_ids : local.public_ids # place ALB in correct subnets
+  lb_access_cidrs  = var.test_data_lb_internal ? concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs)) : local.public_lb_cidrs
+  app_access_cidrs = var.test_data_lb_internal ? concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs)) : concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs),split(",",local.public_cidrs))
 
   concourse_access_cidrs = values(data.vault_generic_secret.shared_services_concourse_cidrs.data)
 }

--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -1,13 +1,20 @@
 terraform {
-  backend "s3" {
+
+  required_version = ">= 0.13.0, < 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.54.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.18.0"
+    }
   }
-}
 
-provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.32.0"
+  backend "s3" {}
 }
-
 
 provider "vault" {
   auth_login {
@@ -19,7 +26,7 @@ provider "vault" {
 }
 
 module "ecs-cluster" {
-  source = "git::git@github.com:companieshouse/terraform-library-ecs-cluster.git?ref=1.1.1"
+  source = "git::git@github.com:companieshouse/terraform-library-ecs-cluster.git?ref=1.1.7"
 
   stack_name                 = local.stack_name
   name_prefix                = local.name_prefix

--- a/groups/stack/module-ecs-services/test-data-generator.tf
+++ b/groups/stack/module-ecs-services/test-data-generator.tf
@@ -82,7 +82,8 @@ resource "aws_lb_listener_rule" "test-data-generator" {
     target_group_arn = aws_lb_target_group.test-data-generator-target_group.arn
   }
   condition {
-    field  = "path-pattern"
-    values = ["/test-data/*"]
+    path_pattern {
+      values = ["/test-data/*"]
+    }
   }
 }

--- a/groups/stack/module-ecs-stack/load-balancer.tf
+++ b/groups/stack/module-ecs-stack/load-balancer.tf
@@ -22,7 +22,7 @@ resource "aws_lb_listener" "test-data-lb-listener" {
 }
 
 resource "aws_route53_record" "test-data-generator-r53-record" {
-  count   = "${var.zone_id == "" ? 0 : 1}" # zone_id defaults to empty string giving count = 0 i.e. not route 53 record
+  count   = var.zone_id == "" ? 0 : 1 # zone_id defaults to empty string giving count = 0 i.e. not route 53 record
   zone_id = var.zone_id
   name    = "test-data${var.external_top_level_domain}"
   type    = "A"


### PR DESCRIPTION
Updates the terraform code to work with TF 0.13.  This is an intermediate step in upgrading to TF 1.3.

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2873