### PR TITLE
Changes to upgrade to TF 1.3

### DIFF
--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -1,6 +1,6 @@
 terraform {
 
-  required_version = ">= 0.13.0, < 0.14"
+  required_version = "~> 1.3"
 
   required_providers {
     aws = {
@@ -26,8 +26,9 @@ provider "vault" {
 }
 
 module "ecs-cluster" {
-  source = "git::git@github.com:companieshouse/terraform-library-ecs-cluster.git?ref=1.1.7"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.275"
 
+  aws_profile                = var.aws_profile
   stack_name                 = local.stack_name
   name_prefix                = local.name_prefix
   environment                = var.environment
@@ -35,7 +36,6 @@ module "ecs-cluster" {
   subnet_ids                 = local.application_ids
   ec2_key_pair_name          = var.ec2_key_pair_name
   ec2_instance_type          = var.ec2_instance_type
-  ec2_image_id               = var.ec2_image_id
   asg_max_instance_count     = var.asg_max_instance_count
   asg_min_instance_count     = var.asg_min_instance_count
   asg_desired_instance_count = var.asg_desired_instance_count

--- a/groups/stack/module-ecs-stack/security-groups.tf
+++ b/groups/stack/module-ecs-stack/security-groups.tf
@@ -38,7 +38,7 @@ resource "aws_security_group_rule" "web_https" {
 }
 
 resource "aws_security_group_rule" "concourse_http" {
-  for_each = toset(var.concourse_access_cidrs)
+  for_each = nonsensitive(toset(var.concourse_access_cidrs))
 
   type              = "ingress"
   from_port         = 80
@@ -49,7 +49,7 @@ resource "aws_security_group_rule" "concourse_http" {
 }
 
 resource "aws_security_group_rule" "concourse_https" {
-  for_each = toset(var.concourse_access_cidrs)
+  for_each = nonsensitive(toset(var.concourse_access_cidrs))
 
   type              = "ingress"
   from_port         = 443

--- a/groups/stack/module-secrets/parameters.tf
+++ b/groups/stack/module-secrets/parameters.tf
@@ -1,5 +1,5 @@
 resource "aws_ssm_parameter" "secret_parameters" {
-  for_each = var.secrets
+  for_each = nonsensitive(var.secrets)
     name  = "/${var.name_prefix}/${each.key}"
     key_id = var.kms_key_id
     description = each.key

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -53,11 +53,6 @@ variable "ec2_instance_type" {
   type        = string
   description = "The instance type for ec2 instances in the clusters."
 }
-variable "ec2_image_id" {
-  default     = "ami-007ef488b3574da6b" # ECS optimized Linux in London created 16/10/2019
-  type        = string
-  description = "The machine image name for the ECS cluster launch configuration."
-}
 
 # Auto-scaling Group
 variable "asg_max_instance_count" {


### PR DESCRIPTION
Updates the terraform code to work with TF 1.3 and to use the latest ecs-cluster version.

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2873
