### PR TITLE
Reference new version of ecs-cluster module

### DIFF
--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -26,7 +26,7 @@ provider "vault" {
 }
 
 module "ecs-cluster" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.275"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.276"
 
   aws_profile                = var.aws_profile
   stack_name                 = local.stack_name


### PR DESCRIPTION
Use 1.0.276 of ecs-cluster module to resolve issue with clash of kms alias in accounts where the stack is deployed to multiple environments.

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2873