### PR TITLE
Updated config for bar code service URL

### DIFF
--- a/groups/stack/module-ecs-services/test-data-generator-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/test-data-generator-task-definition.tmpl
@@ -49,7 +49,7 @@
         "environment": [
             { "name": "PORT", "value": "${tdg_proxy_port}" },
             { "name": "LOGLEVEL", "value": "${log_level}" },
-            { "name": "BARCODE_SERVICE_URL", "value": "http://barcode${external_top_level_domain}" },
+            { "name": "BARCODE_SERVICE_URL", "value": "https://barcode${external_top_level_domain}" },
             { "name": "API_URL", "value": "https://api${external_top_level_domain}" },
             { "name": "ELASTIC_SEARCH_DEPLOYED", "value": "${elastic_search_deployed}" }
         ],


### PR DESCRIPTION
Updated config for bar code service URL so that it passes through the https route which will find it's way to ECS as opposed to Mesos where Bar code generator has been switched off and is throwing 502 errors